### PR TITLE
Minimal set of defines needed for TBase to work.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -593,7 +593,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 #ifdef XCP
     /* XL currently does not support DML in subqueries. */
     if ((parse->commandType != CMD_SELECT) &&
-        ((parent_root ? parent_root->query_level + 1 : 1) > 1))
+        ((parent_root ? parent_root->query_level + 1 : 1) > 1) && !IS_PGXC_DATANODE)
         ereport(ERROR,
                 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                  errmsg("INSERT/UPDATE/DELETE is not supported in subquery")));

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -387,8 +387,8 @@
 
 
 /* all code written by Tencent Team must be in macro __TBASE__ block*/
-#define __TBASE__ 0
-#define __SUPPORT_DISTRIBUTED_TRANSACTION__ 0
+#define __TBASE__ 1
+#define __SUPPORT_DISTRIBUTED_TRANSACTION__ 1
 //#define __PAGE_TIMESTAMP_LOG__ 0
 //#define __USE_GLOBAL_SNAPSHOT__ 0
 #ifdef __SUPPORT_DISTRIBUTED_TRANSACTION__
@@ -404,11 +404,11 @@
 #define _MLS_ 0
 #define __AUDIT_FGA__
 #define __STORAGE_SCALABLE__ 0
-#define __XLOG__ 0
-#define __COLD_HOT__ 0
+#define __XLOG__ 1
+#define __COLD_HOT__ 1
 #define __SUBSCRIPTION__ 0
 #define _PUB_SUB_RELIABLE_ 0
-#define __TWO_PHASE_TRANS__ 0
+#define __TWO_PHASE_TRANS__ 1
 //#define __TWO_PHASE_TESTS__ 0
 /* MAX NODES NUMBER of the cluster */
 #define     MAX_NODES_NUMBER             4096


### PR DESCRIPTION
As ./configure does not reset these and compile succeeds but leaves a lot of dead code that is needed to function.